### PR TITLE
Correct mysql connection failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 out
 gen
+
+# Ignore swap files
+*.swp
+

--- a/code/mysql/Dockerfile
+++ b/code/mysql/Dockerfile
@@ -5,4 +5,7 @@ LABEL maintainer "Peter Fisher"
 LABEL image_type "MYSQL database server"
 
 # Copy over the schema files
-ADD /schemas /schemas
+COPY /schemas /schemas
+
+# Replace mysql config file with one that includes native password support
+COPY /config/my.cnf /etc/mysql/my.cnf

--- a/code/mysql/config/my.cnf
+++ b/code/mysql/config/my.cnf
@@ -1,0 +1,33 @@
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+#
+# The MySQL  Server configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysqld]
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+datadir         = /var/lib/mysql
+secure-file-priv= NULL
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# Custom config should go here
+!includedir /etc/mysql/conf.d/
+default_authentication_plugin=mysql_native_password
+


### PR DESCRIPTION
After building the images and connecting to the website, the following
error is reported:
   The server requested authentication method unknown to the client
To correct this, native password support is added to the mysql config.

> Add mysql/config directory
> Add my.cnf file in mysql/config that includes the native password
  support directive
> Update mysql image Dockerfile to copy the my.cnf file to the image
> Update .gitignore to ignore swap files